### PR TITLE
Fix for missing region

### DIFF
--- a/bin/PipLibraryInstaller/installPipModuleAsRedshiftLibrary.sh
+++ b/bin/PipLibraryInstaller/installPipModuleAsRedshiftLibrary.sh
@@ -99,7 +99,7 @@ wheelFile=`find . -name *.whl`
 zipFile=$module.zip
 mv $wheelFile $zipFile
 
-aws s3 cp $zipFile $s3Prefix$zipFile
+aws s3 cp $zipFile $s3Prefix$zipFile --region $region
 
 if [ $? != 0 ]; then
 	rm -Rf "$TMPDIR/.$module"

--- a/bin/PipLibraryInstaller/installPipModuleAsRedshiftLibrary.sh
+++ b/bin/PipLibraryInstaller/installPipModuleAsRedshiftLibrary.sh
@@ -8,7 +8,7 @@ function usage {
 	echo
 	echo "where <module> is the name of the Pip module to be installed"
 	echo "      <upload prefix> is the location on S3 to upload the artifact to. Must be in format s3://bucket/prefix/"
-	echo "      <region> is the optional region where the S3 bucket was created"
+	echo "      <region> is the region where the S3 bucket was created"
 	echo
 	
 	exit 0;
@@ -56,6 +56,7 @@ done
 # validate arguments
 notNull "$module" "Please provide the pip module name using -m"
 notNull "$s3Prefix" "Please provide an S3 Prefix to store the library in using -s"
+notNull "$region" "Please provide a S3 region using -r"
 
 # check that the s3 prefix is in the right format
 # starts with 's3://'


### PR DESCRIPTION
Utilizing this shell script as is, I was running into some issues.

Currently, my team is looking into potentially using the `lifelines` library within Redshift - what's working out so far is that the requirements for `lifelines` seem to align with the existing Redshift Python libraries: `scipy`, `pandas`, etc.

However, using the script as is, was running into some issues. As I walked through the steps, discovered that the script was failing during the `aws s3 cp` command.

```
# lifelines being the 'library'

$ aws s3 cp lifelines.zip s3://<bucket-name>/<prefix>/lifelines.zip
```

Returned message:
```
A region must be specified --region or specifying the region
in a configuration file or as an environment variable.
Alternately, an endpoint can be specified with --endpoint-url
```

Upon providing `$region` to this command, I was able to successfully upload. Figured I'd offer up this PR in case any one else runs into this issue as well.